### PR TITLE
Switches to the AdoptOpenJDK image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jdk-alpine
+FROM adoptopenjdk/openjdk8:alpine
 
 RUN apk add --no-cache curl tar bash jq libxml2-utils
 


### PR DESCRIPTION
TL;DR
-----

Uses AdoptOpenJDK image as a base

Details
-------

Shifted to the AdoptOpenJDK image for good karma, more freedom,
and more general image tags.