### PR TITLE
Removes old Concourse workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@ FROM adoptopenjdk/openjdk8:alpine
 
 RUN apk add --no-cache curl tar bash jq libxml2-utils
 
-# https://github.com/concourse/concourse/issues/2042
-RUN unlink  $JAVA_HOME/jre/lib/security/cacerts && \
-    cp /etc/ssl/certs/java/cacerts $JAVA_HOME/jre/lib/security/cacerts
-
 ADD assets/ /opt/resource/
 ADD test/ /opt/resource/test/
 ADD itest/ /opt/resource/itest/


### PR DESCRIPTION
TL;DR
-----

Deletes workaround related to Concourse cert propagation

Details
-------

There was a workaround in place to handle an issue between Alpine
and Concourse certificate propagation. Things worked without the
workaround in place with the AdoptOpenJDK image and the latest
version of Concourse, so this fix removes the workaround.